### PR TITLE
add missing question to sendToChat() dialog

### DIFF
--- a/webxdc.js
+++ b/webxdc.js
@@ -119,7 +119,7 @@ window.webxdc = (() => {
                 content.file
                   ? `${content.file.name} - ${base64Content.length} bytes`
                   : "No File"
-              }`
+              }\n\nDownload the file in the browser instead?`
             );
             if (confirmed && content.file) {
               var element = document.createElement("a");

--- a/webxdc.js
+++ b/webxdc.js
@@ -112,25 +112,26 @@ window.webxdc = (() => {
                 );
               }
             }
-            const confirmed = confirm(
-              `The app would now close and the user would select a chat to send this message:\nText: ${
+            const msg = `The app would now close and the user would select a chat to send this message:\nText: ${
                 content.text ? `"${content.text}"` : "No Text"
               }\nFile: ${
-                content.file
-                  ? `${content.file.name} - ${base64Content.length} bytes`
-                  : "No File"
-              }\n\nDownload the file in the browser instead?`
-            );
-            if (confirmed && content.file) {
-              var element = document.createElement("a");
-              element.setAttribute(
-                "href",
-                "data:application/octet-stream;base64," + base64Content
-              );
-              element.setAttribute("download", content.file.name);
-              document.body.appendChild(element);
-              element.click();
-              document.body.removeChild(element);
+                content.file ? `${content.file.name} - ${base64Content.length} bytes` : "No File"
+              }`;
+            if (content.file) {
+              const confirmed = confirm(msg + '\n\nDownload the file in the browser instead?');
+              if (confirmed) {
+                var element = document.createElement("a");
+                element.setAttribute(
+                  "href",
+                  "data:application/octet-stream;base64," + base64Content
+                );
+                element.setAttribute("download", content.file.name);
+                document.body.appendChild(element);
+                element.click();
+                document.body.removeChild(element);
+              }
+            } else {
+              alert(msg);
             }
         }
     };


### PR DESCRIPTION
calling sendToChat(), an informational message is shown that has the buttons "OK" and "Cancel" -
but the user has no idea what they're doing and what's the difference:

![Screenshot 2023-06-02 at 12 02 40](https://github.com/webxdc/hello/assets/9800740/10891084-8269-445e-8fa1-1942390b5f8f)


this pr adds the missing question.

![Screenshot 2023-06-02 at 12 01 23](https://github.com/webxdc/hello/assets/9800740/4692c71d-5eae-4844-be86-c23550382953)

successor of #46