### PR TITLE
rename 'Clear Storage' to 'Reset'

### DIFF
--- a/webxdc.js
+++ b/webxdc.js
@@ -234,7 +234,7 @@ window.alterXdcApp = () => {
       '"> | </span>' +
       '<a id="webxdc-panel-clear" href="javascript:window.clearXdcStorage();" style="' +
       styleMenuLink +
-      '">Clear Storage</a>' +
+      '">Reset</a>' +
       "<div>";
     var controlPanel = root.firstChild;
 


### PR DESCRIPTION
it is shorter and makes the control smaller
(which was just grown by adding the title in #54) - but 'Reset' also fits better as it clears localStorage as well as reloading the page.

(the "Add Peer" was unchanged, we can go for "+Peer" in case we add more controls or so, currently it is fine)

successor of #54

![Screenshot 2023-09-08 at 14 03 14](https://github.com/webxdc/hello/assets/9800740/6ae7acbb-6e99-4994-bc78-574829b60c13)
