### PR TITLE
send update.document out

### DIFF
--- a/webxdc.js
+++ b/webxdc.js
@@ -55,6 +55,7 @@ window.webxdc = (() => {
         payload: update.payload,
         summary: update.summary,
         info: update.info,
+        document: update.document,
         serial: serial,
       };
       updates.push(_update);


### PR DESCRIPTION
while it is not displayed currented in the emulator (which would be nice, same as summary and info),
a webxdc may still use the received update.document value.

therefore, it is important to send out out.

closes https://codeberg.org/webxdc/checklist/issues/38