### PR TITLE
app icon shown as page icon too

### DIFF
--- a/webxdc.js
+++ b/webxdc.js
@@ -245,6 +245,11 @@ window.alterXdcApp = () => {
         root.innerHTML =
           '<img src="' + name + '" style="' + styleAppIcon + '">';
         controlPanel.insertBefore(root.firstChild, controlPanel.childNodes[1]);
+        
+        var pageIcon = document.createElement('link');
+        pageIcon.rel = "icon";
+        pageIcon.href = name;
+        document.head.append(pageIcon);
       };
       tester.src = name;
     }


### PR DESCRIPTION
webxdc.js usually shows the app icon in the small board in the left-down part of the screen, now the icon is also shown as page icon too, it's a nice detail I think.